### PR TITLE
feat: add deployment step to Cloudflare Pages in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,3 +82,30 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  deploy:
+    name: deploy
+    needs: [typecheck, lint, format-check, test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Build
+        run: pnpm build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=rehoboam


### PR DESCRIPTION
## What

This update introduces a deployment step to the CI workflow for Cloudflare Pages. The new step ensures that the application is built and deployed automatically after passing the necessary checks. This enhancement streamlines the deployment process and integrates it directly into the CI pipeline.

- Added a new `deploy` job in the CI workflow.

- Configured deployment to Cloudflare Pages using the `wrangler-action`.

- Ensured that the deployment step runs after type checking, linting, formatting checks, and testing.

## How to test

- Run the CI workflow to verify that the deployment step executes correctly after all previous jobs.

- Ensure that the application builds successfully and deploys to Cloudflare Pages.

## Security review

- **Secrets / env vars:** changed. (New secrets for Cloudflare API token and account ID.)

- **Auth / session:** not changed.

- **Network / API calls:** changed. (New deployment calls to Cloudflare Pages.)

- **Data handling / PII:** not changed.

- **Dependencies:** added. (Introduced `cloudflare/wrangler-action` for deployment.)

- No new dependencies and no network calls outside of the deployment process.

- No env var changes and no auth/session logic touched.