### PR TITLE
Fix cloudflare deploy in monorepo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,8 +104,7 @@ jobs:
         run: pnpm --filter web build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy apps/web/dist --project-name=rehoboam
+        run: pnpm dlx wrangler@3 pages deploy apps/web/dist --project-name=rehoboam
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
         run: pnpm --filter web build
 
       - name: Deploy to Cloudflare Pages
-        run: pnpm dlx wrangler@3 pages deploy apps/web/dist --project-name=rehoboam
+        run: pnpm dlx wrangler@3.0.0 pages deploy apps/web/dist --project-name=rehoboam
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## What

- Replace `cloudflare/wrangler-action@v3` with direct `pnpm dlx wrangler@3` call to fix deploy failure after monorepo refactor
- The action uses bare `pnpm add` without `-w` flag when auto-installing wrangler, which fails with `ERR_PNPM_ADDING_TO_ROOT` in pnpm workspaces