### PR TITLE
Rename Cloudflare projects to rehoboam-api and rehoboam-ui

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy Rehoboam UI to Cloudflare Pages
-        run: pnpm dlx wrangler@4.66.0 pages deploy apps/ui/dist --project-name=rehoboam
+        run: pnpm dlx wrangler@4.66.0 pages deploy apps/ui/dist --project-name=rehoboam-ui
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -4,7 +4,7 @@
  */
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "api",
+  "name": "rehoboam-api",
   "main": "src/index.ts",
   "compatibility_date": "2025-09-27",
   "observability": {


### PR DESCRIPTION
## Summary
- Rename API Worker from `api` to `rehoboam-api` in wrangler.jsonc
- Rename Pages project from `rehoboam` to `rehoboam-ui` in deploy workflow

## Notes
- Old `api` worker and `rehoboam` Pages project should be deleted from the CF dashboard after deploy
- Custom domain needs to be reconfigured on the new `rehoboam-ui` Pages project
- CF API token needs Workers Scripts Edit permission for the new worker name
