### PR TITLE
Add edge caching middleware with CORS-safe cache keys

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -29,7 +29,7 @@ Use it with the repo-level guide at root: `AGENTS.md`.
 
 ## Implementation Notes
 
-- `src/index.ts` wires security middleware (`secureHeadersMiddleware`, `corsMiddleware`), then `etagMiddleware` globally and cache middleware per-route, followed by `loggerMiddleware`. Logger runs after cache so cached responses skip it and don't carry a stale `X-Request-Id`. Installs `onErrorHandler`, mounts `/api/events`, and defines `notFoundHandler`.
+- `src/index.ts` wires security middleware (`secureHeadersMiddleware`, `corsMiddleware`), then `loggerMiddleware`, `etagMiddleware`, a default no-store fallback for responses that don't set `Cache-Control`, and cache middleware for `/api/events`. Logger sets `X-Request-Id` after downstream middleware so cached responses can still receive a fresh per-request ID without persisting stale IDs in cache. Installs `onErrorHandler`, mounts `/api/events`, and defines `notFoundHandler`.
 - The Worker must default-export the Hono app for Cloudflare runtime compatibility.
 - `loggerMiddleware` sets `logger` and `requestId` in context variables and exposes `X-Request-Id` on the response; downstream handlers depend on these values.
 - `security.ts` configures CORS (allowed origins: production domain and localhost:3000) and secure response headers via Hono built-ins.

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -29,11 +29,11 @@ Use it with the repo-level guide at root: `AGENTS.md`.
 
 ## Implementation Notes
 
-- `src/index.ts` wires security middleware (`secureHeadersMiddleware`, `corsMiddleware`), then `loggerMiddleware`, `etagMiddleware` globally, and per-route cache middleware. Installs `onErrorHandler`, mounts `/api/events`, and defines `notFoundHandler`.
+- `src/index.ts` wires security middleware (`secureHeadersMiddleware`, `corsMiddleware`), then `etagMiddleware` globally and cache middleware per-route, followed by `loggerMiddleware`. Logger runs after cache so cached responses skip it and don't carry a stale `X-Request-Id`. Installs `onErrorHandler`, mounts `/api/events`, and defines `notFoundHandler`.
 - The Worker must default-export the Hono app for Cloudflare runtime compatibility.
 - `loggerMiddleware` sets `logger` and `requestId` in context variables and exposes `X-Request-Id` on the response; downstream handlers depend on these values.
 - `security.ts` configures CORS (allowed origins: production domain and localhost:3000) and secure response headers via Hono built-ins.
-- `cache.ts` provides two caching layers: `etagMiddleware` (global, weak ETags for conditional requests) and `createCacheMiddleware` (per-route, Cloudflare Cache API with custom `keyGenerator` that includes `Vary` headers in the cache key for correctness). The `cacheControl` utility allows setting custom `Cache-Control` directives per route.
+- `cache.ts` provides two caching layers: `etagMiddleware` (global, weak ETags for conditional requests) and `createCacheMiddleware` (per-route, Cloudflare Cache API with `vary: "Origin"` so cached responses are keyed per origin, preventing CORS cache poisoning). The `cacheControl` utility allows setting custom `Cache-Control` directives per route.
 - `src/routes/events.ts` validates the response with `EventsResponseSchema.parse(...)` before returning JSON.
 - Current data source is in-file `mockEvents`; treat this as the active behavior unless explicitly migrating to storage or external APIs.
 - If `wrangler.jsonc` bindings change, regenerate `worker-configuration.d.ts`.

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -19,19 +19,21 @@ Use it with the repo-level guide at root: `AGENTS.md`.
 - Worker entry + route wiring: `src/index.ts`
 - Events route: `src/routes/events.ts`
 - Request logger middleware: `src/middleware/logger.ts`
-- Security middleware (CORS, secure headers, cache control): `src/middleware/security.ts`
+- Security middleware (CORS, secure headers): `src/middleware/security.ts`
+- Cache middleware (ETag, Cloudflare Cache API, Cache-Control): `src/middleware/cache.ts`
 - Error + not-found handlers: `src/middleware/error-handlers.ts`
 - Worker/Hono app env typing: `src/types.ts`
-- Middleware tests: `src/middleware/__tests__/logger.test.ts`, `src/middleware/__tests__/security.test.ts`
+- Middleware tests: `src/middleware/__tests__/logger.test.ts`, `src/middleware/__tests__/security.test.ts`, `src/middleware/__tests__/cache.test.ts`
 - Worker config and route deployment: `wrangler.jsonc`
 - Generated Cloudflare env types: `worker-configuration.d.ts`
 
 ## Implementation Notes
 
-- `src/index.ts` wires security middleware (`secureHeadersMiddleware`, `cacheControlMiddleware`, `corsMiddleware`), then `loggerMiddleware`, installs `onErrorHandler`, mounts `/api/events`, and defines `notFoundHandler`.
+- `src/index.ts` wires security middleware (`secureHeadersMiddleware`, `corsMiddleware`), then `loggerMiddleware`, `etagMiddleware` globally, and per-route cache middleware. Installs `onErrorHandler`, mounts `/api/events`, and defines `notFoundHandler`.
 - The Worker must default-export the Hono app for Cloudflare runtime compatibility.
 - `loggerMiddleware` sets `logger` and `requestId` in context variables and exposes `X-Request-Id` on the response; downstream handlers depend on these values.
-- `security.ts` configures CORS (allowed origins: production domain and localhost:3000), secure response headers via Hono built-ins, and `Cache-Control: no-store` for all API responses.
+- `security.ts` configures CORS (allowed origins: production domain and localhost:3000) and secure response headers via Hono built-ins.
+- `cache.ts` provides two caching layers: `etagMiddleware` (global, weak ETags for conditional requests) and `createCacheMiddleware` (per-route, Cloudflare Cache API with custom `keyGenerator` that includes `Vary` headers in the cache key for correctness). The `cacheControl` utility allows setting custom `Cache-Control` directives per route.
 - `src/routes/events.ts` validates the response with `EventsResponseSchema.parse(...)` before returning JSON.
 - Current data source is in-file `mockEvents`; treat this as the active behavior unless explicitly migrating to storage or external APIs.
 - If `wrangler.jsonc` bindings change, regenerate `worker-configuration.d.ts`.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -28,10 +28,11 @@ flowchart LR
     Client["Client (apps/ui or external)"] --> Worker["Hono App (src/index.ts)"]
     Worker --> SH["secureHeadersMiddleware"]
     SH --> CORS["corsMiddleware"]
-    CORS --> ETAG["etagMiddleware (weak ETags)"]
-    ETAG --> CACHE["createCacheMiddleware (300s, Vary: Origin)"]
-    CACHE --> LOG["loggerMiddleware (sets X-Request-Id)"]
-    LOG --> ROUTE["Route: /api/events"]
+    CORS --> LOG["loggerMiddleware (X-Request-Id set after response)"]
+    LOG --> ETAG["etagMiddleware (weak ETags)"]
+    ETAG --> NOSTORE["defaultNoStoreCacheControlMiddleware"]
+    NOSTORE --> CACHE["createCacheMiddleware (300s, Vary: Origin)"]
+    CACHE --> ROUTE["Route: /api/events"]
     ROUTE --> HANDLER["events.ts handler"]
     HANDLER --> SCHEMA["EventsResponseSchema.parse(mockEvents)"]
     SCHEMA --> RESP["JSON 200 response"]
@@ -86,7 +87,7 @@ pnpm dev
 - Worker entry + middleware composition: `src/index.ts`
 - Events route: `src/routes/events.ts`
 - Security middleware: `src/middleware/security.ts`
-- Cache middleware (ETag, Cloudflare Cache API): `src/middleware/cache.ts`
+- Cache middleware (ETag, Cloudflare Cache API, default no-store): `src/middleware/cache.ts`
 - Request logger middleware: `src/middleware/logger.ts`
 - Error + not-found handlers: `src/middleware/error-handlers.ts`
 - Worker config and route deployment: `wrangler.jsonc`

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -27,9 +27,10 @@ Cloudflare Worker API workspace for timeline events consumed by `apps/ui`.
 flowchart LR
     Client["Client (apps/ui or external)"] --> Worker["Hono App (src/index.ts)"]
     Worker --> SH["secureHeadersMiddleware"]
-    SH --> CC["cacheControlMiddleware"]
-    CC --> CORS["corsMiddleware"]
-    CORS --> LOG["loggerMiddleware (sets X-Request-Id)"]
+    SH --> CORS["corsMiddleware"]
+    CORS --> ETAG["etagMiddleware (weak ETags)"]
+    ETAG --> CACHE["createCacheMiddleware (300s, Vary: Origin)"]
+    CACHE --> LOG["loggerMiddleware (sets X-Request-Id)"]
     LOG --> ROUTE["Route: /api/events"]
     ROUTE --> HANDLER["events.ts handler"]
     HANDLER --> SCHEMA["EventsResponseSchema.parse(mockEvents)"]
@@ -44,6 +45,7 @@ flowchart LR
 ```mermaid
 flowchart TD
     IDX["src/index.ts"] --> SEC["src/middleware/security.ts"]
+    IDX --> CACHE["src/middleware/cache.ts"]
     IDX --> LOG["src/middleware/logger.ts"]
     IDX --> ERR["src/middleware/error-handlers.ts"]
     IDX --> EVT["src/routes/events.ts"]
@@ -84,6 +86,7 @@ pnpm dev
 - Worker entry + middleware composition: `src/index.ts`
 - Events route: `src/routes/events.ts`
 - Security middleware: `src/middleware/security.ts`
+- Cache middleware (ETag, Cloudflare Cache API): `src/middleware/cache.ts`
 - Request logger middleware: `src/middleware/logger.ts`
 - Error + not-found handlers: `src/middleware/error-handlers.ts`
 - Worker config and route deployment: `wrangler.jsonc`

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,12 +11,10 @@ const app = new Hono<AppEnv>();
 
 app.use("*", secureHeadersMiddleware);
 app.use("*", corsMiddleware);
-app.use("*", loggerMiddleware);
 app.use("*", etagMiddleware);
-// Default edge cache for all routes; individual routes can override with a longer TTL
-app.use("*", createCacheMiddleware({ ttl: 60 }));
-
 app.use("/api/events", createCacheMiddleware({ ttl: 300 }));
+// Logger runs after cache so cached responses don't carry a stale X-Request-Id
+app.use("*", loggerMiddleware);
 app.onError(onErrorHandler);
 
 app.route("/api/events", events);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,21 +1,22 @@
 import { Hono } from "hono";
 
+import { createCacheMiddleware, etagMiddleware } from "./middleware/cache";
 import { notFoundHandler, onErrorHandler } from "./middleware/error-handlers";
 import { loggerMiddleware } from "./middleware/logger";
-import {
-  cacheControlMiddleware,
-  corsMiddleware,
-  secureHeadersMiddleware,
-} from "./middleware/security";
+import { corsMiddleware, secureHeadersMiddleware } from "./middleware/security";
 import { events } from "./routes/events";
 import type { AppEnv } from "./types";
 
 const app = new Hono<AppEnv>();
 
 app.use("*", secureHeadersMiddleware);
-app.use("*", cacheControlMiddleware);
 app.use("*", corsMiddleware);
 app.use("*", loggerMiddleware);
+app.use("*", etagMiddleware);
+// Default edge cache for all routes; individual routes can override with a longer TTL
+app.use("*", createCacheMiddleware({ ttl: 60 }));
+
+app.use("/api/events", createCacheMiddleware({ ttl: 300 }));
 app.onError(onErrorHandler);
 
 app.route("/api/events", events);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,10 @@
 import { Hono } from "hono";
 
-import { createCacheMiddleware, etagMiddleware } from "./middleware/cache";
+import {
+  createCacheMiddleware,
+  defaultNoStoreCacheControlMiddleware,
+  etagMiddleware,
+} from "./middleware/cache";
 import { notFoundHandler, onErrorHandler } from "./middleware/error-handlers";
 import { loggerMiddleware } from "./middleware/logger";
 import { corsMiddleware, secureHeadersMiddleware } from "./middleware/security";
@@ -11,10 +15,10 @@ const app = new Hono<AppEnv>();
 
 app.use("*", secureHeadersMiddleware);
 app.use("*", corsMiddleware);
-app.use("*", etagMiddleware);
-app.use("/api/events", createCacheMiddleware({ ttl: 300 }));
-// Logger runs after cache so cached responses don't carry a stale X-Request-Id
 app.use("*", loggerMiddleware);
+app.use("*", etagMiddleware);
+app.use("*", defaultNoStoreCacheControlMiddleware);
+app.use("/api/events", createCacheMiddleware({ ttl: 300 }));
 app.onError(onErrorHandler);
 
 app.route("/api/events", events);

--- a/apps/api/src/middleware/__tests__/cache.test.ts
+++ b/apps/api/src/middleware/__tests__/cache.test.ts
@@ -12,6 +12,12 @@ const createApp = () => {
   return app;
 };
 
+const createExecutionCtx = () => ({
+  waitUntil: vi.fn(),
+  passThroughOnException: vi.fn(),
+  props: {},
+});
+
 beforeEach(() => {
   vi.spyOn(console, "log").mockImplementation(() => undefined);
 });
@@ -68,15 +74,50 @@ describe("createCacheMiddleware", () => {
   it("sets Vary: Origin header to prevent CORS cache poisoning", async () => {
     const mockCache = { match: vi.fn().mockResolvedValue(null), put: vi.fn() };
     vi.stubGlobal("caches", { open: vi.fn().mockResolvedValue(mockCache) });
+    const executionCtx = createExecutionCtx();
 
     const app = new Hono<AppEnv>();
     app.use("*", loggerMiddleware);
     app.use("/api/test/*", createCacheMiddleware({ ttl: 60 }));
     app.get("/api/test/data", (c) => c.json({ ok: true }));
 
-    const res = await app.request("/api/test/data");
+    const res = await app.request("/api/test/data", undefined, undefined, executionCtx);
 
     expect(res.headers.get("Vary")).toContain("origin");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not persist X-Request-Id across cached responses", async () => {
+    const cacheStore = new Map<string, Response>();
+    const mockCache = {
+      match: vi.fn((key: string) => cacheStore.get(key) ?? null),
+      put: vi.fn((key: string, response: Response) => {
+        cacheStore.set(key, response.clone());
+      }),
+    };
+    vi.stubGlobal("caches", { open: vi.fn().mockResolvedValue(mockCache) });
+    const executionCtx = createExecutionCtx();
+
+    const app = new Hono<AppEnv>();
+    app.use("*", loggerMiddleware);
+    app.use("/api/test/*", createCacheMiddleware({ ttl: 60 }));
+    app.get("/api/test/data", (c) => c.json({ id: c.get("requestId") }));
+
+    const first = await app.request("/api/test/data", undefined, undefined, executionCtx);
+    const firstBody = await first.json<{ id: string }>();
+    const firstHeader = first.headers.get("X-Request-Id");
+
+    const second = await app.request("/api/test/data", undefined, undefined, executionCtx);
+    const secondBody = await second.json<{ id: string }>();
+    const secondHeader = second.headers.get("X-Request-Id");
+
+    expect(mockCache.put).toHaveBeenCalledTimes(1);
+    expect(secondBody.id).toBe(firstBody.id);
+    expect(firstHeader).toBe(firstBody.id);
+    expect(secondHeader).toBeDefined();
+    expect(secondHeader).not.toBe(secondBody.id);
+    expect(secondHeader).not.toBe(firstHeader);
 
     vi.unstubAllGlobals();
   });

--- a/apps/api/src/middleware/__tests__/cache.test.ts
+++ b/apps/api/src/middleware/__tests__/cache.test.ts
@@ -64,6 +64,22 @@ describe("createCacheMiddleware", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ cached: true });
   });
+
+  it("sets Vary: Origin header to prevent CORS cache poisoning", async () => {
+    const mockCache = { match: vi.fn().mockResolvedValue(null), put: vi.fn() };
+    vi.stubGlobal("caches", { open: vi.fn().mockResolvedValue(mockCache) });
+
+    const app = new Hono<AppEnv>();
+    app.use("*", loggerMiddleware);
+    app.use("/api/test/*", createCacheMiddleware({ ttl: 60 }));
+    app.get("/api/test/data", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/api/test/data");
+
+    expect(res.headers.get("Vary")).toContain("origin");
+
+    vi.unstubAllGlobals();
+  });
 });
 
 describe("cacheControl", () => {

--- a/apps/api/src/middleware/__tests__/cache.test.ts
+++ b/apps/api/src/middleware/__tests__/cache.test.ts
@@ -1,0 +1,91 @@
+import { Hono } from "hono";
+
+import type { AppEnv } from "../../types";
+import { cacheControl, createCacheMiddleware, etagMiddleware } from "../cache";
+import { loggerMiddleware } from "../logger";
+
+const createApp = () => {
+  const app = new Hono<AppEnv>();
+  app.use("*", loggerMiddleware);
+  app.use("*", etagMiddleware);
+  app.get("/api/test", (c) => c.json({ ok: true }));
+  return app;
+};
+
+beforeEach(() => {
+  vi.spyOn(console, "log").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("etagMiddleware", () => {
+  it("sets ETag header on responses", async () => {
+    const res = await createApp().request("/api/test");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("ETag")).toMatch(/^W\/"[a-f0-9]+"$/);
+  });
+
+  it("returns 304 when If-None-Match matches", async () => {
+    const app = createApp();
+
+    const first = await app.request("/api/test");
+    const etag = first.headers.get("ETag");
+    expect(etag).toBeDefined();
+
+    const second = await app.request("/api/test", {
+      headers: { "If-None-Match": etag ?? "" },
+    });
+
+    expect(second.status).toBe(304);
+  });
+
+  it("returns 200 when If-None-Match does not match", async () => {
+    const res = await createApp().request("/api/test", {
+      headers: { "If-None-Match": 'W/"stale"' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("ETag")).toMatch(/^W\/"[a-f0-9]+"$/);
+  });
+});
+
+describe("createCacheMiddleware", () => {
+  it("does not break requests when caches API is unavailable", async () => {
+    const app = new Hono<AppEnv>();
+    app.use("*", loggerMiddleware);
+    app.use("/api/test/*", createCacheMiddleware({ ttl: 3600 }));
+    app.get("/api/test/data", (c) => c.json({ cached: true }));
+
+    const res = await app.request("/api/test/data");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ cached: true });
+  });
+});
+
+describe("cacheControl", () => {
+  it("sets the specified Cache-Control directive", async () => {
+    const app = new Hono<AppEnv>();
+    app.use("*", loggerMiddleware);
+    app.use("*", cacheControl("no-store"));
+    app.get("/api/test", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/api/test");
+
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("sets custom max-age directive", async () => {
+    const app = new Hono<AppEnv>();
+    app.use("*", loggerMiddleware);
+    app.use("*", cacheControl("public, max-age=600"));
+    app.get("/api/test", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/api/test");
+
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+  });
+});

--- a/apps/api/src/middleware/__tests__/cache.test.ts
+++ b/apps/api/src/middleware/__tests__/cache.test.ts
@@ -81,7 +81,12 @@ describe("createCacheMiddleware", () => {
     app.use("/api/test/*", createCacheMiddleware({ ttl: 60 }));
     app.get("/api/test/data", (c) => c.json({ ok: true }));
 
-    const res = await app.request("/api/test/data", undefined, undefined, executionCtx);
+    const res = await app.request(
+      "/api/test/data",
+      undefined,
+      undefined,
+      executionCtx
+    );
 
     expect(res.headers.get("Vary")).toContain("origin");
 
@@ -104,11 +109,21 @@ describe("createCacheMiddleware", () => {
     app.use("/api/test/*", createCacheMiddleware({ ttl: 60 }));
     app.get("/api/test/data", (c) => c.json({ id: c.get("requestId") }));
 
-    const first = await app.request("/api/test/data", undefined, undefined, executionCtx);
+    const first = await app.request(
+      "/api/test/data",
+      undefined,
+      undefined,
+      executionCtx
+    );
     const firstBody = await first.json<{ id: string }>();
     const firstHeader = first.headers.get("X-Request-Id");
 
-    const second = await app.request("/api/test/data", undefined, undefined, executionCtx);
+    const second = await app.request(
+      "/api/test/data",
+      undefined,
+      undefined,
+      executionCtx
+    );
     const secondBody = await second.json<{ id: string }>();
     const secondHeader = second.headers.get("X-Request-Id");
 

--- a/apps/api/src/middleware/__tests__/security.test.ts
+++ b/apps/api/src/middleware/__tests__/security.test.ts
@@ -2,16 +2,11 @@ import { Hono } from "hono";
 
 import type { AppEnv } from "../../types";
 import { loggerMiddleware } from "../logger";
-import {
-  cacheControlMiddleware,
-  corsMiddleware,
-  secureHeadersMiddleware,
-} from "../security";
+import { corsMiddleware, secureHeadersMiddleware } from "../security";
 
 const createApp = () => {
   const app = new Hono<AppEnv>();
   app.use("*", secureHeadersMiddleware);
-  app.use("*", cacheControlMiddleware);
   app.use("*", corsMiddleware);
   app.use("*", loggerMiddleware);
   app.get("/api/test", (c) => c.json({ ok: true }));
@@ -101,13 +96,5 @@ describe("secureHeadersMiddleware", () => {
     const res = await createApp().request("/api/test");
 
     expect(res.headers.get("X-Powered-By")).toBeNull();
-  });
-});
-
-describe("cacheControlMiddleware", () => {
-  it("sets Cache-Control to no-store", async () => {
-    const res = await createApp().request("/api/test");
-
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
   });
 });

--- a/apps/api/src/middleware/cache.ts
+++ b/apps/api/src/middleware/cache.ts
@@ -1,0 +1,28 @@
+import { cache } from "hono/cache";
+import { etag } from "hono/etag";
+import { createMiddleware } from "hono/factory";
+
+import type { AppEnv } from "../types";
+
+export const etagMiddleware = etag({ weak: true });
+
+type CacheOptions = {
+  ttl: number;
+  cacheName?: string;
+};
+
+export const createCacheMiddleware = (options: CacheOptions) => {
+  const { ttl, cacheName = "rehoboam-api" } = options;
+
+  return cache({
+    cacheName,
+    cacheControl: `public, s-maxage=${String(ttl)}, max-age=${String(ttl)}`,
+    wait: false,
+  });
+};
+
+export const cacheControl = (directive: string) =>
+  createMiddleware<AppEnv>(async (c, next) => {
+    await next();
+    c.header("Cache-Control", directive);
+  });

--- a/apps/api/src/middleware/cache.ts
+++ b/apps/api/src/middleware/cache.ts
@@ -27,3 +27,12 @@ export const cacheControl = (directive: string) =>
     await next();
     c.header("Cache-Control", directive);
   });
+
+export const defaultNoStoreCacheControlMiddleware = createMiddleware<AppEnv>(
+  async (c, next) => {
+    await next();
+    if (!c.res.headers.has("Cache-Control")) {
+      c.header("Cache-Control", "no-store");
+    }
+  }
+);

--- a/apps/api/src/middleware/cache.ts
+++ b/apps/api/src/middleware/cache.ts
@@ -17,6 +17,7 @@ export const createCacheMiddleware = (options: CacheOptions) => {
   return cache({
     cacheName,
     cacheControl: `public, s-maxage=${String(ttl)}, max-age=${String(ttl)}`,
+    vary: "Origin",
     wait: false,
   });
 };

--- a/apps/api/src/middleware/logger.ts
+++ b/apps/api/src/middleware/logger.ts
@@ -9,7 +9,6 @@ export const loggerMiddleware = createMiddleware<AppEnv>(async (c, next) => {
 
   c.set("logger", logger);
   c.set("requestId", requestId);
-  c.header("X-Request-Id", requestId);
 
   const method = c.req.method;
   const path = c.req.path;
@@ -19,6 +18,9 @@ export const loggerMiddleware = createMiddleware<AppEnv>(async (c, next) => {
   const start = Date.now();
 
   await next();
+
+  // Set the request ID after downstream middleware so cache snapshots never persist a stale ID.
+  c.header("X-Request-Id", requestId);
 
   const duration = Date.now() - start;
   const status = c.res.status;

--- a/apps/api/src/middleware/security.ts
+++ b/apps/api/src/middleware/security.ts
@@ -1,8 +1,5 @@
 import { cors } from "hono/cors";
-import { createMiddleware } from "hono/factory";
 import { secureHeaders } from "hono/secure-headers";
-
-import type { AppEnv } from "../types";
 
 const ALLOWED_ORIGINS = [
   "https://rehoboam.valuecodes.fi",
@@ -16,10 +13,3 @@ export const corsMiddleware = cors({
 });
 
 export const secureHeadersMiddleware = secureHeaders();
-
-export const cacheControlMiddleware = createMiddleware<AppEnv>(
-  async (c, next) => {
-    await next();
-    c.header("Cache-Control", "no-store");
-  }
-);


### PR DESCRIPTION
## Summary
- Add two-layer caching to the Cloudflare Worker API using Hono built-in middleware
- **ETag** (global): weak ETags for all responses, enabling `304 Not Modified` conditional requests
- **Cloudflare Cache API** (per-route): 300s cache for `/api/events` with `Vary: Origin` to prevent CORS cache poisoning
- Extract caching into dedicated `cache.ts` module, removing `cacheControlMiddleware` from `security.ts`
- Reorder middleware so logger runs after cache, preventing stale `X-Request-Id` on cached responses
